### PR TITLE
fix: anchor link in readme for `Payments API v2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 The PayPal Server SDK provides integration access to the PayPal REST APIs. The API endpoints are divided into distinct controllers:
 
 - Orders Controller: [Orders API v2](https://developer.paypal.com/docs/api/orders/v2/)
-- Payments Controller: [Payments API v2](https://developer.paypal.com/docs/api/payments/v2
+- Payments Controller: [Payments API v2](https://developer.paypal.com/docs/api/payments/v2)
 - Vault Controller: [Payment Method Tokens API v3](https://developer.paypal.com/docs/api/payment-tokens/v3/) *Available in the US only.*
 
 ## Install the Package


### PR DESCRIPTION
This pull request includes a minor correction to the `README.md` file. The change fixes a broken link to the Payments API v2 documentation by adding a missing closing parenthesis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a broken URL link in the README for the Payments Controller API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->